### PR TITLE
Stop Simulation using Pygame

### DIFF
--- a/lineflow/simulation/line.py
+++ b/lineflow/simulation/line.py
@@ -178,7 +178,7 @@ class Line:
 
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
-                teardown_draw()
+                self.teardown_draw()
                 sys.exit()
 
         screen.fill('white')


### PR DESCRIPTION
Added code to "line.py" where the pygame_quit event is registered. This should allow the user to end the simulation early by clicking the X button on the visualisation window.